### PR TITLE
Using more compact and readable serialization for exported files.

### DIFF
--- a/MscrmTools.PortalRecordsMover/MscrmTools.PortalRecordsMover.csproj
+++ b/MscrmTools.PortalRecordsMover/MscrmTools.PortalRecordsMover.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cinteros.Xrm.CRMWinForm, Version=2017.6.19.17, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cinteros.Xrm.CRMWinForm.2017.6.19.17\lib\net452\Cinteros.Xrm.CRMWinForm.dll</HintPath>
+    </Reference>
     <Reference Include="McTools.Xrm.Connection, Version=1.2017.5.14, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
       <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2017.5.14\lib\net452\McTools.Xrm.Connection.dll</HintPath>
       <Private>True</Private>

--- a/MscrmTools.PortalRecordsMover/packages.config
+++ b/MscrmTools.PortalRecordsMover/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Cinteros.Xrm.CRMWinForm" version="2017.6.19.17" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />


### PR DESCRIPTION
The serialization is now used from [CRMWinForm](https://www.nuget.org/packages/Cinteros.Xrm.CRMWinForm) NuGet package, which can serialize ``EntityCollection`` to a more "readable" and non-bloated xml format compared to the ``DataContractSerialization``.

_No need at all to accept this PR, if you don't like it :)_