### PR TITLE
adding check for the entity in metadata cache

### DIFF
--- a/MscrmTools.PortalRecordsMover/AppCode/RecordManager.cs
+++ b/MscrmTools.PortalRecordsMover/AppCode/RecordManager.cs
@@ -100,7 +100,7 @@ namespace MscrmTools.PortalRecordsMover.AppCode
                     var emd = emds.FirstOrDefault(e => e.LogicalName == record.LogicalName);
                     if (emd == null)
                     {
-                        logger.LogInfo($"Record: Entity Logical Name: {record.LogicalName} for ID: {record.Id} not found in the target instance metadata.");
+                        logger.LogError($"Record: Entity Logical Name: {record.LogicalName} for ID: {record.Id} not found in the target instance metadata.");
                         continue;
                     }
 

--- a/MscrmTools.PortalRecordsMover/AppCode/RecordManager.cs
+++ b/MscrmTools.PortalRecordsMover/AppCode/RecordManager.cs
@@ -97,7 +97,13 @@ namespace MscrmTools.PortalRecordsMover.AppCode
                 var entityProgress = progress.Entities.FirstOrDefault(e => e.LogicalName == record.LogicalName);
                 if (entityProgress == null)
                 {
-                    var emd = emds.First(e => e.LogicalName == record.LogicalName);
+                    var emd = emds.FirstOrDefault(e => e.LogicalName == record.LogicalName);
+                    if (emd == null)
+                    {
+                        logger.LogInfo($"Record: Entity Logical Name: {record.LogicalName} for ID: {record.Id} not found in the target instance metadata.");
+                        continue;
+                    }
+
                     string displayName = emd.DisplayName?.UserLocalizedLabel?.Label;
 
                     if (displayName == null && emd.IsIntersect.Value)


### PR DESCRIPTION
if an entity type was exported but it is not found in the target environment, there is an exception.  added check and continue to processing method.  The missing entity logical name and record ID will be logged but not displayed in the main list (no emd for display name)
(example: adx_geography is not in two new environments i just created)